### PR TITLE
Add files via upload

### DIFF
--- a/Chess Game/board.py
+++ b/Chess Game/board.py
@@ -61,7 +61,7 @@ class Board:
     Returns(None)
     '''
     def draw(self, screen):
-        for row in self.squares:
+        for row in self.squares:            
             for square in row:
                 square.draw(screen)
     
@@ -156,3 +156,15 @@ class Board:
             return line_moves(horizontal_and_vertical_directions)
         elif isinstance(piece, Queen):
             return line_moves(diagonal_directions+horizontal_and_vertical_directions)
+    
+    '''
+    Moves a piece on the board.
+    Args(Piece: piece, int:row, int:col)
+    Returns(None)
+    '''
+    def move(self, piece, row, col):
+        initial_square = Square(piece.row, piece.col)
+        piece.row = row
+        piece.col = col
+        final_square = Square(row, col, piece)
+        self.squares[row][col], self.squares[initial_square.row][initial_square.col] = final_square, initial_square

--- a/Chess Game/game.py
+++ b/Chess Game/game.py
@@ -11,6 +11,8 @@ class Game:
         self.running = True
         self.board = Board()
         self.players_turn = 'white' # white always starts
+        self.selected_piece = None
+        self.selected_piece_moves = []
 
         self.run()
 
@@ -38,9 +40,17 @@ class Game:
                     piece = self.board.squares[clicked_row][clicked_col].piece
                     
                     if piece.colour == self.players_turn: # checks if that piece belongs to the player who clicked it
-                        moves = self.board.get_moves(piece, clicked_row, clicked_col)
-                        print(moves)
-                    
+                        self.selected_piece_moves = self.board.get_moves(piece, clicked_row, clicked_col)
+                        self.selected_piece = piece
+
+            if event.type == pygame.MOUSEBUTTONUP:
+                move = [event.pos[1]//SQ_WIDTH, event.pos[0]//SQ_HEIGHT]
+                if self.selected_piece != None:
+                    if move in self.selected_piece_moves:
+                        self.board.move(self.selected_piece, move[0], move[1])
+                        
+
+
             # exits the game
             elif event.type == pygame.QUIT:
                 pygame.quit()

--- a/Chess Game/square.py
+++ b/Chess Game/square.py
@@ -4,8 +4,8 @@ from settings import *
 class Square:
     # initializes the square
     def __init__(self, row, col, piece=None):
-        self.x = row
-        self.y = col
+        self.row = row
+        self.col = col
         self.piece = piece
         self.colour = LIGHT_BEIGE if (row+col)%2 == 0 else GREEN
         self.rect = pygame.Rect(col*SQ_WIDTH, row*SQ_HEIGHT, SQ_WIDTH, SQ_HEIGHT)
@@ -18,5 +18,8 @@ class Square:
     '''
     def draw(self, screen):
         pygame.draw.rect(screen, self.colour, self.rect)
-        if self.piece:
-            self.piece.draw(screen)
+        try:
+            if self.piece:
+                self.piece.draw(screen)
+        except:
+            print('whoops')


### PR DESCRIPTION
The knight, bishop, rook, and queen can be moved on the board.

To-do:
- castling
- king moves
- pawn moves: moving 2 squares for first move, en passant, capturing, promotion
- not allowing moves that dont remove a check when the player is in check
- switching to the next players move
- allowing the selected piece to be dragged while the player moves it
- showing the player which squares it can be moved to when they select it